### PR TITLE
Fix async tool call bug in StatefulToolEnv

### DIFF
--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 from verifiers.envs.tool_env import ToolEnv
 from verifiers.types import ChatCompletionMessageToolCall, Message, Messages, State
+from verifiers.utils.async_utils import maybe_await
 from verifiers.utils.tool_utils import convert_func_to_oai_tool
 
 
@@ -40,7 +41,7 @@ class StatefulToolEnv(ToolEnv):
         """Call a tool based on JSON command."""
         try:
             tool_func = self.tool_map[tool_name]
-            result = str(tool_func(**tool_args))
+            result = await maybe_await(tool_func, **tool_args)
             return {
                 "role": "tool",
                 "content": str(result),


### PR DESCRIPTION
StatefulToolEnv was not properly awaiting async tool functions, unlike the parent ToolEnv class which uses maybe_await. This fix adds the missing import and updates call_tool to use maybe_await for consistent async/sync tool support.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `uv run pytest`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->